### PR TITLE
Handle mobile docking class and panel selectors

### DIFF
--- a/app.js
+++ b/app.js
@@ -957,6 +957,7 @@
     dock.querySelector('#md-help').appendChild(right);
 
     switchMobileTab('tools');
+    document.body.classList.add('mobile-docked');
     isMobileUI = true;
   }
   function exitMobileDock(){
@@ -967,6 +968,7 @@
     if (leftPH && left)  leftPH.parentNode.insertBefore(left, leftPH);
     if (rightPH && right) rightPH.parentNode.insertBefore(right, rightPH);
     if (dock) dock.style.display = 'none';
+    document.body.classList.remove('mobile-docked');
     isMobileUI = false;
   }
   function handleResponsivePanels(){

--- a/styles.css
+++ b/styles.css
@@ -88,8 +88,8 @@ label.chk{ gap:6px; }
   }
   /* Antes estaba: #leftPanel, #rightPanel { display:none } */
   /* Ahora solo se ocultan cuando el JS ya los movió al dock */
-  body.mobile-docked #leftPanel,
-  body.mobile-docked #rightPanel { display: none; }
+  body.mobile-docked #app > #leftPanel,
+  body.mobile-docked #app > #rightPanel { display: none; }
 }
 
 


### PR DESCRIPTION
## Summary
- add `mobile-docked` body class when entering/exiting mobile dock
- refine mobile CSS selectors to hide only original panels

## Testing
- `node --check app.js`
- `node - <<'NODE' ... NODE` (simulate enter/exit mobile dock)
- `npm test` *(fails: Error: no test specified)*
- `npm install jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68be26dec67c832aba846cdcbf66f66f