### PR TITLE
Handle absence of ResizeObserver with fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -1103,8 +1103,12 @@
     document.getElementById('btnHandHUD').addEventListener('click', ()=> { handMode = !handMode; canvas.skipTargetFind = handMode; canvas.defaultCursor = handMode ? 'grab' : 'default'; document.getElementById('btnHandHUD').classList.toggle('active', handMode); });
 
     // Fit inicial + cambios de tamaño de contenedor
-    const ro = new ResizeObserver(()=> { if(autoCenter) fitToViewport(); });
-    ro.observe(document.getElementById('viewport'));
+    if ('ResizeObserver' in window) {
+      const ro = new ResizeObserver(()=> { if(autoCenter) fitToViewport(); });
+      ro.observe(document.getElementById('viewport'));
+    } else {
+      window.addEventListener('resize', ()=>{ if(autoCenter) fitToViewport(); });
+    }
     requestAnimationFrame(()=> requestAnimationFrame(()=> { autoCenter=true; fitToViewport(); }));
 
     // Dock móvil


### PR DESCRIPTION
## Summary
- Guard ResizeObserver usage with a feature check
- Fallback to window resize listener when ResizeObserver is unavailable

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be26f431bc832aa4a1a5fbf2f01973