### PR TITLE
Add crop dialog fallback for browsers without <dialog> support

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,26 @@
 (() => {
   const $ = (s)=>document.querySelector(s);
 
+  // ===== Dialog support detection =====
+  function supportsDialog(){ return 'HTMLDialogElement' in window; }
+  const hasDialog = supportsDialog();
+  function openModal(el){ hasDialog ? el.showModal() : el.classList.add('open'); }
+  function closeModal(el){ hasDialog ? el.close() : el.classList.remove('open'); }
+  if(!hasDialog){
+    const dlg = document.getElementById('cropModal');
+    if(dlg){
+      const wrap = document.createElement('div');
+      wrap.id = dlg.id;
+      wrap.className = 'modal-fallback';
+      const content = document.createElement('div');
+      content.className = 'modal-content';
+      content.innerHTML = dlg.innerHTML;
+      wrap.appendChild(content);
+      dlg.replaceWith(wrap);
+      document.body.classList.add('no-dialog');
+    }
+  }
+
   // ====== Responsive desktop bar ======
   const mq = window.matchMedia('(min-width: 768px)');
   function toggleDeskBar(e){ document.getElementById('deskBar').style.display = e.matches ? 'flex' : 'none'; }
@@ -510,11 +530,11 @@
     const imgEl = document.getElementById('cropperImage');
     const orig = t.__origSrc || t._originalElement?.src || t.getElement?.().src || t.toDataURL({format:'png'});
     imgEl.src = orig;
-    const dlg = document.getElementById('cropModal'); dlg.showModal();
+    const dlg = document.getElementById('cropModal'); openModal(dlg);
     if (cropper) { cropper.destroy(); cropper = null; }
     cropper = new Cropper(imgEl, { viewMode:1, background:false, autoCrop:true, checkOrientation:false, responsive:true, dragMode:'move', autoCropArea:0.9 });
   }
-  document.getElementById('cmClose').onclick = () => { if (cropper) { cropper.destroy(); cropper = null; } document.getElementById('cropModal').close(); };
+  document.getElementById('cmClose').onclick = () => { if (cropper) { cropper.destroy(); cropper = null; } closeModal(document.getElementById('cropModal')); };
   document.getElementById('cmZoomIn').onclick  = ()=> cropper && cropper.zoom( 0.1);
   document.getElementById('cmZoomOut').onclick = ()=> cropper && cropper.zoom(-0.1);
   document.getElementById('cmRotate').onclick  = ()=> cropper && cropper.rotate(90);
@@ -539,7 +559,7 @@
       if(idx >= 0){ canvas.insertAt(img, idx, true); } else { canvas.add(img); }
       canvas.setActiveObject(img); canvas.requestRenderAll();
     }, { crossOrigin:'anonymous' });
-    cropTarget = null; cropper.destroy(); cropper = null; document.getElementById('cropModal').close();
+    cropTarget = null; cropper.destroy(); cropper = null; closeModal(document.getElementById('cropModal'));
   };
 
   // ===== Feather helpers =====

--- a/styles.css
+++ b/styles.css
@@ -132,7 +132,18 @@ label.chk{ gap:6px; }
 
 /* Cropper dialog */
 #cropModal::backdrop{ background: rgba(0,0,0,.3); }
-#cropModal{ border:none; padding:0; max-width:min(95vw, 960px); width:95vw; }
+#cropModal,
+.no-dialog #cropModal .modal-content{ border:none; padding:0; max-width:min(95vw, 960px); width:95vw; background:#fff; }
+.no-dialog #cropModal{
+  position:fixed;
+  inset:0;
+  display:none;
+  align-items:center;
+  justify-content:center;
+  background:rgba(0,0,0,.3);
+  z-index:1000;
+}
+.no-dialog #cropModal.open{ display:flex; }
 .cropper-wrap{ max-height:65vh; overflow:auto; padding:12px; }
 .cropper-wrap img{ max-width:100%; display:block; margin:0 auto; }
 .cropper-toolbar{ display:flex; gap:8px; align-items:center; padding:10px; border-top:1px solid var(--border); }


### PR DESCRIPTION
## Summary
- Detect `<dialog>` support and dynamically replace crop dialog with a styled `<div>` when unsupported
- Wrap dialog show/close in helpers for manual open/close
- Style fallback modal to mimic native dialog behavior

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be26fe20e8832ab0e2967e365f8e7f