### PR TITLE
Ensure viewport uses full grid height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,7 @@ label.chk{ gap:6px; }
   background: repeating-conic-gradient(#f3f4f6 0% 25%, #fff 0% 50%) 50% / 20px 20px;
   border:1px solid var(--border); border-radius:12px; position:relative; min-height: 300px;
   display:flex; align-items:center; justify-content:center; overflow:hidden;
+  height: 100%;
 }
 #stage{ outline:none; }
 


### PR DESCRIPTION
## Summary
- Add `height: 100%` to `#viewport` so the canvas fills the available layout height.
- Confirm the layout grid (`#app`) continues to use `height: calc(100vh - 56px)` for consistent viewport sizing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68befba6887c832a9f203e0a65e58269