### PR TITLE
Auto-center canvas after starting new project

### DIFF
--- a/app.js
+++ b/app.js
@@ -1028,6 +1028,8 @@
       if(vignetteRect){ canvas.add(vignetteRect); }
       orderBackground();
       canvas.discardActiveObject(); canvas.requestRenderAll(); updateSelInfo();
+      autoCenter = true;
+      fitToViewport();
     });
 
     // Texto


### PR DESCRIPTION
## Summary
- Ensure new canvas starts centered by enabling autoCenter and fitting to the viewport when the "New" button is clicked.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68befba156f8832aa8e730e3224474b6