### PR TITLE
Permite que el lienzo móvil se contraiga correctamente

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,8 +85,9 @@ label.chk{ gap:6px; }
 @media (max-width: 767px){
   #app{
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto 1fr auto;
   }
+  #viewport{ min-height: 0; }
   /* Antes estaba: #leftPanel, #rightPanel { display:none } */
   /* Ahora solo se ocultan cuando el JS ya los movió al dock */
   body.mobile-docked #app > #leftPanel,


### PR DESCRIPTION
## Summary
- Ajusta `grid-template-rows` en la media query móvil para que el contenedor central ocupe el espacio flexible.
- Añade `#viewport { min-height: 0; }` en móvil para permitir que el lienzo se contraiga.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a852840832a954d6aaf594410e4