### PR TITLE
Use dynamic viewport height

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,12 @@
 (() => {
   const $ = (s)=>document.querySelector(s);
 
+  const setHeaderHeight = () => {
+    const el = document.getElementById('deskBar');
+    document.documentElement.style.setProperty('--header-h', `${el?.offsetHeight || 0}px`);
+  };
+  window.addEventListener('resize', setHeaderHeight);
+
   // ===== Dialog support detection =====
   function supportsDialog(){ return 'HTMLDialogElement' in window; }
   const hasDialog = supportsDialog();
@@ -23,7 +29,10 @@
 
   // ====== Responsive desktop bar ======
   const mq = window.matchMedia('(min-width: 768px)');
-  function toggleDeskBar(e){ document.getElementById('deskBar').style.display = e.matches ? 'flex' : 'none'; }
+  function toggleDeskBar(e){
+    document.getElementById('deskBar').style.display = e.matches ? 'flex' : 'none';
+    setHeaderHeight();
+  }
   toggleDeskBar(mq); mq.addEventListener('change', toggleDeskBar);
 
   function syncDrawers(){

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
   --border: #e5e7eb;
   --text: #0f172a;
   --muted: #64748b;
+  --header-h: 56px;
 }
 
 /* Base de botones (global) */
@@ -37,7 +38,7 @@ body{
 /* Layout principal */
 #app{
   display:grid; grid-template-columns: 280px 1fr 300px; grid-template-rows: 1fr;
-  gap:12px; padding:12px; height: calc(100vh - 56px);
+  gap:12px; padding:12px; height: calc(100dvh - var(--header-h));
 }
 
 /* Paneles */


### PR DESCRIPTION
## Summary
- Use `100dvh` with CSS variable for header height in app layout
- Compute `--header-h` from `deskBar` height via JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a87495c832a87517b5c133879ae