### PR TITLE
Ensure canvas fits after responsive panel transitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -995,6 +995,7 @@
     switchMobileTab('tools');
     document.body.classList.add('mobile-docked');
     isMobileUI = true;
+    requestAnimationFrame(()=>fitToViewport());
   }
   function exitMobileDock(){
     if (!isMobileUI) return;
@@ -1006,10 +1007,12 @@
     if (dock) dock.style.display = 'none';
     document.body.classList.remove('mobile-docked');
     isMobileUI = false;
+    requestAnimationFrame(()=>fitToViewport());
   }
   function handleResponsivePanels(){
     const mobile = window.matchMedia('(max-width: 767px)').matches;
     if (mobile) enterMobileDock(); else exitMobileDock();
+    requestAnimationFrame(()=>fitToViewport());
   }
   function overrideOpenersForMobile(){
     const btnOpenTools = document.getElementById('btnOpenTools');


### PR DESCRIPTION
## Summary
- Adjust canvas to viewport after responsive panel handling
- Recenter canvas after mobile dock transitions

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0e0b79d0832a9044f0734e0c2677