### PR TITLE
Initialize header height before canvas load

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@
   const setHeaderHeight = () => {
     const el = document.getElementById('deskBar');
     document.documentElement.style.setProperty('--header-h', `${el?.offsetHeight || 0}px`);
+    fitToViewport();
   };
   window.addEventListener('resize', setHeaderHeight);
 
@@ -1028,6 +1029,7 @@
 
   // ===== DOMContentLoaded =====
   window.addEventListener('DOMContentLoaded', async ()=>{
+    setHeaderHeight();
     injectGoogleFonts();
     populateFontSelect();
     buildFontPicker();


### PR DESCRIPTION
## Summary
- Calculate header height on DOM load before canvas initialization
- Refit canvas whenever header height variable changes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0e0da208832a80de77dd10e18e43