### PR TITLE
Declare canvas and guide variables before viewport fit

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,9 @@
 (() => {
   const $ = (s)=>document.querySelector(s);
 
+  let canvas, showGuides=true, hGuide=null, vGuide=null, vignetteRect=null;
+  let paperRect=null, paperShadowRect=null;
+
   const setHeaderHeight = () => {
     const el = document.getElementById('deskBar');
     document.documentElement.style.setProperty('--header-h', `${el?.offsetHeight || 0}px`);
@@ -74,9 +77,6 @@
     "A4L":   { w:2970, h:2100 }  // 297x210 mm
   };
   let baseW=1080, baseH=1080;
-
-  let canvas, showGuides=true, hGuide=null, vGuide=null, vignetteRect=null;
-  let paperRect=null, paperShadowRect=null;
 
   let autoCenter = true;
   let handMode   = false;


### PR DESCRIPTION
## Summary
- Move canvas and guide-related variables to top of app.js IIFE so fitToViewport can safely reference them

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf11906ac4832a9c66b42111f3f205