### PR TITLE
Invoke toggleDeskBar after canvas initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@
     document.getElementById('deskBar').style.display = e.matches ? 'flex' : 'none';
     setHeaderHeight();
   }
-  toggleDeskBar(mq); mq.addEventListener('change', toggleDeskBar);
+  mq.addEventListener('change', toggleDeskBar);
 
   function syncDrawers(){
     const isDesktop = window.matchMedia('(min-width: 768px)').matches;
@@ -1038,6 +1038,7 @@
     buildFontPicker();
 
     initCanvas();
+    toggleDeskBar(mq);
 
     // Formato
     document.getElementById('selAspect').addEventListener('change',(e)=> setAspect(e.target.value));


### PR DESCRIPTION
## Summary
- Remove early desktop bar toggle invocation
- Ensure desktop bar initializes after canvas is created

## Testing
- `npm test` *(fails: enoent no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf11921ec4832aa605541c221f4b19