### PR TITLE
Limit mobile dock height for small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,10 @@ label.chk{ gap:6px; }
     grid-template-rows: auto 1fr auto;
   }
   #viewport{ min-height: 0; }
+  #mobileDock{
+    max-height:50dvh;
+    overflow:auto;
+  }
   body.mobile-docked #mobileDock{ display:block; grid-row:3; }
   /* Antes estaba: #leftPanel, #rightPanel { display:none } */
   /* Ahora solo se ocultan cuando el JS ya los movió al dock */


### PR DESCRIPTION
## Summary
- Limit `#mobileDock` height to 50dvh and enable scrolling to keep canvas visible on small screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3352261c832aba382864452e8bc9