### PR TITLE
Add A5 paper option and set as default canvas size

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,9 +74,11 @@
     "16:9":  { w:1920, h:1080 },
     // ISO 216 A4 (1:√2) base 10px/mm
     "A4P":   { w:2100, h:2970 }, // 210x297 mm
-    "A4L":   { w:2970, h:2100 }  // 297x210 mm
+    "A4L":   { w:2970, h:2100 }, // 297x210 mm
+    "A5P":   { w:1480, h:2100 },
+    "A5L":   { w:2100, h:1480 }
   };
-  let baseW=1080, baseH=1080;
+  let baseW=1480, baseH=2100;
 
   let autoCenter = true;
   let handMode   = false;

--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
               <option value="16:9">16:9</option>
               <option value="A4P">A4 (vertical)</option>
               <option value="A4L">A4 (horizontal)</option>
+              <option value="A5P" selected>A5 (vertical)</option>
+              <option value="A5L">A5 (horizontal)</option>
             </select>
           </label>
           <label>Fondo <input id="inpBg" type="color" value="#ffffff" /></label>


### PR DESCRIPTION
## Summary
- add A5 portrait and landscape presets to aspect list
- default canvas size set to A5 portrait

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf335419c4832a913df1b3e4408275