### PR TITLE
Enable PDF compression in export

### DIFF
--- a/app.js
+++ b/app.js
@@ -722,8 +722,9 @@
     const out = isMono() ? await toGray(data) : data;
     const { jsPDF } = window.jspdf;
     const w = baseW * mult, h = baseH * mult;
-    const pdf=new jsPDF({ unit:'px', format:[w,h], orientation: (w>=h?'landscape':'portrait') });
-    pdf.addImage(out,'PNG',0,0,w,h,undefined,'FAST'); pdf.save('diseño.pdf');
+    const pdf = new jsPDF({ unit: 'px', format: [w, h], orientation: (w >= h ? 'landscape' : 'portrait'), compress: true });
+    pdf.addImage(out, 'JPEG', 0, 0, w, h, undefined, 'MEDIUM', 0.8);
+    pdf.save('diseño.pdf');
   }
 
   // ===== Imprimir múltiple (auto layout + hints) =====


### PR DESCRIPTION
## Summary
- Enable compression when exporting designs to PDF via jsPDF
- Export images as medium-quality JPEG with adjustable quality parameter

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3357e218832a8f42879e81008d05