### PR TITLE
Ensure canvas fits viewport on reload

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+
 (() => {
   const $ = (s)=>document.querySelector(s);
 
@@ -1162,7 +1164,12 @@
     } else {
       window.addEventListener('resize', ()=>{ if(autoCenter) fitToViewport(); });
     }
-    requestAnimationFrame(()=> requestAnimationFrame(()=> { autoCenter=true; fitToViewport(); }));
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        autoCenter = true;
+        fitToViewport(true); // asegura scroll al tope
+      })
+    );
 
     // Dock móvil
     handleResponsivePanels();


### PR DESCRIPTION
## Summary
- Prevent browser auto-scroll restoration so the canvas starts at the top after reloads
- Use nested requestAnimationFrame to auto-center and fit the canvas to the viewport, forcing scroll to top

## Testing
- `node --check app.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68bf5159439c832a836fa818d351da64