### PR TITLE
Reset scroll when updating header height

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
   const setHeaderHeight = () => {
     const el = document.getElementById('deskBar');
     document.documentElement.style.setProperty('--header-h', `${el?.offsetHeight || 0}px`);
-    fitToViewport();
+    fitToViewport(true);
   };
   window.addEventListener('resize', setHeaderHeight);
 


### PR DESCRIPTION
## Summary
- Reset viewport scroll whenever header height changes by calling `fitToViewport(true)`.

## Testing
- `node --check app.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf54324e78832aac63e84c3869243a