### PR TITLE
Define mobile grid rows for panels

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -88,8 +88,10 @@ label.chk{ gap:6px; }
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr auto;
   }
-  #viewport{ min-height: 0; }
-  #mobileDock{
+  #leftPanel    { grid-row: 1; }
+  #viewport     { grid-row: 2; min-height: 0; }
+  #mobileDock   {
+    grid-row: 3;
     max-height:50dvh;
     overflow:auto;
   }


### PR DESCRIPTION
## Summary
- Set explicit grid rows for left panel, viewport, and mobile dock on small screens
- Keep existing rules that hide panels when docked

## Testing
- `npm test` *(fails: package.json not found)*
- Manually verified layout: canvas stays centered and fully visible when switching between desktop and mobile widths


------
https://chatgpt.com/codex/tasks/task_e_68bf58a9b864832aa0681f3a8e44f8c3