### PR TITLE
Ensure canvas fits within visible viewport

### DIFF
--- a/app.js
+++ b/app.js
@@ -387,7 +387,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     const outer = document.getElementById('viewport');
     if(!outer||!canvas) return;
     const ow = outer.clientWidth;
-    const oh = outer.clientHeight;
+    const oh = Math.min(outer.clientHeight, window.innerHeight);
     if(ow <= 0 || oh <= 0){
       requestAnimationFrame(()=>fitToViewport(scrollTop));
       return;


### PR DESCRIPTION
## Summary
- Adjust `fitToViewport` to respect the window height, ensuring the canvas always fits the visible viewport.
- Preserve re-calculation via `requestAnimationFrame` when dimensions are zero.

## Testing
- `node -c app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf58ad10a4832aadd2eced8c81ed39