### PR TITLE
Sync design info during pan and zoom

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,6 +412,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       canvas.setViewportTransform(vpt);
     }
     updateZoomLabel();
+    updateDesignInfo();
   }
   function clientToCanvasPoint(clientX, clientY){
     const rect = canvas.upperCanvasEl.getBoundingClientRect();
@@ -441,6 +442,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       vpt[5] += (e.clientY - lastClient.y);
       lastClient={x:e.clientX,y:e.clientY};
       canvas.requestRenderAll();
+      updateDesignInfo();
     });
     const endDrag=()=>{ if(isDragging){ isDragging=false; canvas.selection=true; canvas.defaultCursor = (handMode||spaceDown)?'grab':'default'; } };
     canvas.on('mouse:up', endDrag);
@@ -460,6 +462,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
         vpt[5] += (mid.y - lastMid.y);
         canvas.setViewportTransform(vpt);
         updateZoomLabel();
+        updateDesignInfo();
       }
       lastDist = dist; lastMid = mid; } }, {passive:false});
     el.addEventListener('touchend', (e)=>{ if(e.touches.length<2){ pinchActive=false; } }, {passive:false});
@@ -472,6 +475,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       autoCenter = false;
       canvas.zoomToPoint(midCanvas, z);
       updateZoomLabel();
+      updateDesignInfo();
       opt.e.preventDefault(); opt.e.stopPropagation();
     });
   }


### PR DESCRIPTION
## Summary
- Update design info when panning, pinching, mouse wheel zoom, and programmatic zoom to keep origin in sync

## Testing
- `node --check app.js`
- Manual verification not possible in this environment

------
https://chatgpt.com/codex/tasks/task_e_68c079f51ce0832a963d468e7dee0dfe