### PR TITLE
Align canvas to viewport top on reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -396,7 +396,8 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     const w = canvas.getWidth(), h = canvas.getHeight();
     const s  = Math.max(MIN_Z, Math.min(MAX_Z, Math.min((ow - M)/w, (oh - M)/h)));
     const tx = (ow - w*s) / 2;
-    const ty = (oh - h*s) / 2;
+    let ty = (oh - h*s) / 2;
+    if(scrollTop){ ty += h * s; }
     canvas.setViewportTransform([s,0,0,s,tx,ty]); updateZoomLabel(); updateDesignInfo();
     if (scrollTop) window.scrollTo(0, 0);
   }


### PR DESCRIPTION
## Summary
- shift canvas translation downward when resetting with `scrollTop` so its top edge aligns with the viewport

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c084a96adc832a83d65e1d6e49fc06