### PR TITLE
Centrar lienzo al ajustar al viewport

### DIFF
--- a/app.js
+++ b/app.js
@@ -387,12 +387,11 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     const w = canvas.getWidth(), h = canvas.getHeight();
     const s  = Math.max(MIN_Z, Math.min(MAX_Z, Math.min((ow - M)/w, (oh - M)/h)));
     const tx = (ow - w*s) / 2;
-    let ty = (oh - h*s) / 2;
-    if(scrollTop){ ty = 0; }
+    let ty = (oh - h*s) / 2;    // mantener centrado
     canvas.setViewportTransform([s,0,0,s,tx,ty]);
+    if (scrollTop) window.scrollTo(0,0);
     updateZoomLabel();
     updateDesignInfo();
-    if (scrollTop) window.scrollTo(0, 0);
   }
   function zoomTo(newZ, centerPoint, recenter=false){
     const z = Math.max(MIN_Z, Math.min(MAX_Z, newZ));


### PR DESCRIPTION
## Summary
- Mantener el lienzo centrado en `fitToViewport`, eliminando el ajuste condicionado de desplazamiento vertical y aplicando la transformación del lienzo con el margen calculado

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a004bbf4832a89ded13594d274f2