### PR TITLE
Ensure canvas offset recalculates with zoom

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,3 @@
 Incluye centrado estable, pan con mano (botón, Space o dos dedos), y zoom que respeta el pan. Abre index.html.
+
+Por defecto usa formato A5 y ajusta el lienzo al alto visible en móviles.

--- a/app.js
+++ b/app.js
@@ -161,7 +161,6 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
         <span class="fp-caret">▾</span>
       </button>
       <div class="fp-panel" role="listbox" aria-label="Tipografías">
-        <div class="fp-search"><input type="text" placeholder="Buscar tipografía…" aria-label="Buscar tipografía"></div>
         <div class="fp-list" id="fpList"></div>
       </div>
     `;
@@ -169,21 +168,17 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     const current = host.querySelector('.fp-current');
     const panel = host.querySelector('.fp-panel');
     const list = host.querySelector('#fpList');
-    const search = host.querySelector('.fp-search input');
-
     // Forzar legibilidad por si el CSS global está oscuro
-    [trigger, panel, search].forEach(el=>{
+    [trigger, panel].forEach(el=>{
       if(el){ el.style.background = '#fff'; el.style.color = '#0f172a'; el.style.borderColor = '#e5e7eb'; }
     });
 
     let items = [];
     let selectedIndex = 0;
 
-    const renderList = (filterText='') => {
-      const q = filterText.trim().toLowerCase();
+    const renderList = () => {
       list.innerHTML = '';
-      items = FONT_SET.map((f, idx) => ({...f, idx}))
-                      .filter(f => !q || f.name.toLowerCase().includes(q));
+      items = FONT_SET.map((f, idx) => ({...f, idx}));
       items.forEach((f, i) => {
         const el = document.createElement('div');
         el.className = 'fp-item';
@@ -203,13 +198,12 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     };
     const indexInFiltered = (globalIdx) => items.findIndex(it => it.idx === globalIdx);
     const updateActiveItem = () => {
-      [...list.children].forEach((el, i) => { el.setAttribute('aria-selected', i === selectedIndex ? 'true' : 'false'); });
+      [...list.children].forEach((el, i) => {
+        el.setAttribute('aria-selected', i === selectedIndex ? 'true' : 'false');
+      });
       const active = list.children[selectedIndex];
-      if (active) {
-        const r = active.getBoundingClientRect();
-        const lr = list.getBoundingClientRect();
-        if (r.top < lr.top) list.scrollTop += r.top - lr.top - 8;
-        if (r.bottom > lr.bottom) list.scrollTop += r.bottom - lr.bottom + 8;
+      if (active && active.scrollIntoView) {
+        active.scrollIntoView({ block: 'nearest' });
       }
     };
     const openPanel = () => {
@@ -217,9 +211,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       if (isFabricEditing()) return;
       trigger.setAttribute('aria-expanded', 'true');
       panel.classList.add('open');
-      search.value = '';
-      renderList('');
-      if (!isFabricEditing()) setTimeout(() => search.focus(), 0);
+      renderList();
     };
     const closePanel = () => {
       trigger.setAttribute('aria-expanded', 'false');
@@ -265,7 +257,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       if (e.key === 'Escape') { e.preventDefault(); closePanel(); return; }
       if (e.key === 'ArrowDown') { e.preventDefault(); selectedIndex = Math.min(selectedIndex + 1, items.length - 1); updateActiveItem(); return; }
       if (e.key === 'ArrowUp')   { e.preventDefault(); selectedIndex = Math.max(selectedIndex - 1, 0); updateActiveItem(); return; }
-      if (e.key === 'Enter' && e.target !== search) {
+      if (e.key === 'Enter') {
         e.preventDefault();
         const globalIdx = items[selectedIndex]?.idx;
         if (globalIdx != null) chooseByIndex(globalIdx);
@@ -278,11 +270,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       if (isOpen) closePanel(); else openPanel();
     });
     document.addEventListener('click', (e) => { if (!host.contains(e.target)) closePanel(); });
-    search.addEventListener('input', () => renderList(search.value));
 
     const def = FONT_SET[0];
     current.textContent = def.name; current.style.fontFamily = def.family;
-    renderList('');
+    renderList();
   }
 
   // ====== Lienzo y fondo ======
@@ -397,8 +388,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     const s  = Math.max(MIN_Z, Math.min(MAX_Z, Math.min((ow - M)/w, (oh - M)/h)));
     const tx = (ow - w*s) / 2;
     let ty = (oh - h*s) / 2;
-    if(scrollTop){ ty += h * s; }
-    canvas.setViewportTransform([s,0,0,s,tx,ty]); updateZoomLabel(); updateDesignInfo();
+    if(scrollTop){ ty = 0; }
+    canvas.setViewportTransform([s,0,0,s,tx,ty]);
+    updateZoomLabel();
+    updateDesignInfo();
     if (scrollTop) window.scrollTo(0, 0);
   }
   function zoomTo(newZ, centerPoint, recenter=false){
@@ -1169,10 +1162,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
 
     // Fit inicial + cambios de tamaño de contenedor
     if ('ResizeObserver' in window) {
-      const ro = new ResizeObserver(()=> { if(autoCenter) fitToViewport(); });
+      const ro = new ResizeObserver(()=> { if(autoCenter) fitToViewport(true); });
       ro.observe(document.getElementById('viewport'));
     } else {
-      window.addEventListener('resize', ()=>{ if(autoCenter) fitToViewport(); });
+      window.addEventListener('resize', ()=>{ if(autoCenter) fitToViewport(true); });
     }
     requestAnimationFrame(() =>
       requestAnimationFrame(() => {

--- a/styles.css
+++ b/styles.css
@@ -120,14 +120,11 @@ label.chk{ gap:6px; }
 }
 .fp-panel.open { display: block; }
 
-.fp-search { padding: 8px 10px; border-bottom: 1px solid #f3f4f6; }
-.fp-search input { width: 100%; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 8px; outline: none; }
-
-.fp-list { max-height: 260px; overflow: auto; padding: 6px; }
-.fp-item { padding: 10px 12px; border-radius: 8px; cursor: pointer; display: flex; align-items: center; gap: 10px; }
+.fp-list { padding: 6px; }
+.fp-item { padding: 10px 12px; border-radius: 8px; cursor: pointer; }
 .fp-item:hover, .fp-item[aria-selected="true"] { background: #f3f4f6; }
-.fp-name { font-size: 14px; min-width: 130px; color: #111827; }
-.fp-preview { font-size: 16px; color: #374151; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fp-name { font-size: 14px; color: #111827; display:block; }
+.fp-preview { font-size: 16px; color: #374151; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display:block; margin-top:4px; }
 
 /* Mobile Dock */
 .md-tabs { display: flex; gap: 8px; }
@@ -165,7 +162,7 @@ label.chk{ gap:6px; }
   :root{ --bg:#0b1220; --panel:#0f172a; --border:#243244; --text:#e5e7eb; --muted:#93a4b6; }
   #viewport{ background: #0f172a; }
   label input, label select, #deskBar button, .row button, .cropper-toolbar button{ background:#0b1220; color:var(--text); border-color:var(--border); }
-  .fp-trigger, .fp-panel, .fp-search input, .md-tabs button{ background:#0b1220; border-color:#243244; color:var(--text); }
+  .fp-trigger, .fp-panel, .md-tabs button{ background:#0b1220; border-color:#243244; color:var(--text); }
   .fp-item:hover, .fp-item[aria-selected="true"], .md-tabs button.active { background:#101826; }
 }
 
@@ -210,8 +207,7 @@ button,
 
 /* === Font picker: forzar tema claro y texto legible === */
 .font-picker .fp-trigger,
-.font-picker .fp-panel,
-.font-picker .fp-search input {
+.font-picker .fp-panel {
   background: #fff !important;
   color: #0f172a !important;
   border-color: #e5e7eb !important;
@@ -286,7 +282,6 @@ button,
 /* Inputs al 100% del ancho disponible */
 input[type="text"],
 input[type="number"],
-input[type="color"],
 input[type="file"],
 select,
 .font-picker .fp-trigger{
@@ -308,8 +303,7 @@ select,
 select,
 input,
 .font-picker .fp-trigger,
-.font-picker .fp-panel,
-.font-picker .fp-search input{
+.font-picker .fp-panel{
   background:#fff !important;
   color:#0f172a !important;
   border:1px solid var(--border) !important;
@@ -320,14 +314,11 @@ input,
 /* El panel del font-picker no se sale del ancho */
 .font-picker{ width: 100%; }
 .font-picker .fp-panel{
-  max-height: 240px;
-  overflow: auto;
   margin-top: 6px;
   width: 100%;
 }
 .font-picker .fp-list .fp-item{
-  display:flex; justify-content:space-between; align-items:center;
-  gap:8px; padding:6px 8px; border-radius:6px;
+  padding:6px 8px; border-radius:6px;
 }
 .font-picker .fp-item:hover,
 .font-picker .fp-item[aria-selected="true"]{ background:#f3f4f6 !important; }
@@ -485,7 +476,7 @@ label{ display: grid; gap: var(--gap-sm); font-size: 12px; color: var(--muted); 
 label > input, label > select{ margin-top: 2px; }
 
 /* Controles al 100% */
-input[type="text"], input[type="number"], input[type="color"], input[type="file"],
+input[type="text"], input[type="number"], input[type="file"],
 select, #fontPicker, #fontPicker .fp-trigger{ width: 100%; }
 
 /* Botones que envuelven si no entra todo */
@@ -496,10 +487,12 @@ select, #fontPicker, #fontPicker .fp-trigger{ width: 100%; }
 
 /* Forzar tema claro para legibilidad */
 select, input, button,
-#fontPicker .fp-trigger, #fontPicker .fp-panel, #fontPicker .fp-search input{
+#fontPicker .fp-trigger, #fontPicker .fp-panel{
   background:#fff !important; color:#0f172a !important; border:1px solid var(--border) !important;
   border-radius:8px; padding:8px;
 }
+
+input[type="color"]{ width:32px; height:32px; padding:0; }
 
 /* ===== Acordeón basado en <h3> dentro de .group ===== */
 .group{


### PR DESCRIPTION
## Summary
- Recalculate vertical offset in `fitToViewport` so scroll-to-top aligns canvas regardless of zoom
- Trigger scroll-to-top fit from resize observers and window resize when auto-centering
- Simplify font picker by removing search box and stacking preview text
- Make color pickers compact with square 32px swatches
- Let the font picker rely on the tool pane scroll instead of its own nested scrollbar

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68be25ff6c60832a83e5ddc552d6983f