### PR TITLE
Ajustar desplazamiento de la ventana según offset real

### DIFF
--- a/app.js
+++ b/app.js
@@ -398,8 +398,8 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     updateZoomLabel();
     updateDesignInfo();
     if (scrollTop) {
-      const top = outer.getBoundingClientRect().top + window.scrollY;
-      window.scrollTo(0, top);
+      const diff = outer.getBoundingClientRect().top;
+      if (diff !== 0) window.scrollBy(0, diff);
     }
 
   }


### PR DESCRIPTION
## Summary
- Ajusta `fitToViewport` para desplazar la ventana usando `scrollBy` solo cuando exista un desfase.

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0c297ae34832ab967db2ae761a86f