### PR TITLE
Clamp canvas position when larger than viewport

### DIFF
--- a/app.js
+++ b/app.js
@@ -386,14 +386,21 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     const M = 24;
     const w = canvas.getWidth(), h = canvas.getHeight();
     const s  = Math.max(MIN_Z, Math.min(MAX_Z, Math.min((ow - M)/w, (oh - M)/h)));
-    const tx = (ow - w*s) / 2;
 
+    let tx = (ow - w*s) / 2;
     let ty = (oh - h*s) / 2;
-    if(scrollTop){ ty = 0; }
+
+    // Anchor to top/left if scaled canvas exceeds the viewport
+    if (w * s > ow) tx = 0;
+    if (scrollTop || h * s > oh) ty = 0;
+
     canvas.setViewportTransform([s,0,0,s,tx,ty]);
     updateZoomLabel();
     updateDesignInfo();
-    if (scrollTop) window.scrollTo(0, 0);
+    if (scrollTop) {
+      const diff = outer.getBoundingClientRect().top;
+      if (diff !== 0) window.scrollBy(0, diff);
+    }
 
   }
   function zoomTo(newZ, centerPoint, recenter=false){


### PR DESCRIPTION
## Summary
- Prevent tall or wide canvases from drifting offscreen by clamping the translation when scaled dimensions exceed the viewport
- Scroll using the viewport's real offset so negative positions no longer hide the canvas

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0096f30832aacc77c6b80b216cb