### PR TITLE
Adjust viewport scroll alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -401,7 +401,7 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       const rect = outer.getBoundingClientRect();
       const header = document.getElementById('deskBar');
       const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
-      const diff = rect.top - headerBottom;
+      const diff = headerBottom - rect.top;
       if (Math.abs(diff) > 1) window.scrollBy(0, diff);
 
     }


### PR DESCRIPTION
## Summary
- update the scroll offset calculation in `fitToViewport` so it scrolls in the correct direction when aligning below the header

## Testing
- not run (manual testing pending)


------
https://chatgpt.com/codex/tasks/task_e_68c88bfff860832a9f12acd0cd9e480e