### PR TITLE
Adjust viewport scrolling for format changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -398,11 +398,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     updateZoomLabel();
     updateDesignInfo();
     if (scrollTop) {
-      const rect = outer.getBoundingClientRect();
       const header = document.getElementById('deskBar');
-      const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
-      const diff = headerBottom - rect.top;
-      if (Math.abs(diff) > 1) window.scrollBy(0, diff);
+      const headerHeight = header?.offsetHeight || 0;
+      const target = outer.getBoundingClientRect().top + window.scrollY - headerHeight;
+      window.scrollTo({ top: target, left: 0, behavior: 'instant' });
 
     }
 


### PR DESCRIPTION
## Summary
- adjust the fitToViewport scroll calculation to factor the header height
- switch to window.scrollTo with an explicit target so the canvas stays visible when changing formats

## Testing
- Manual: toggled between A5/A4 vertical and horizontal formats via Playwright to confirm the viewport stays fully visible


------
https://chatgpt.com/codex/tasks/task_e_68c89246371c832aad41d4c4aa21b802