### PR TITLE
Add debug logging to DOMContentLoaded initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -1076,13 +1076,33 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
 
   // ===== DOMContentLoaded =====
   window.addEventListener('DOMContentLoaded', async ()=>{
+    console.log('setHeaderHeight: start');
     setHeaderHeight();
-    injectGoogleFonts();
-    populateFontSelect();
-    buildFontPicker();
+    console.log('setHeaderHeight: done');
 
-    initCanvas();
+    console.log('injectGoogleFonts: start');
+    injectGoogleFonts();
+    console.log('injectGoogleFonts: done');
+
+    console.log('populateFontSelect: start');
+    populateFontSelect();
+    console.log('populateFontSelect: done');
+
+    console.log('buildFontPicker: start');
+    buildFontPicker();
+    console.log('buildFontPicker: done');
+
+    console.log('initCanvas: start');
+    try {
+      initCanvas();
+      console.log('initCanvas: done');
+    } catch (error) {
+      console.error('initCanvas: error', error);
+    }
+
+    console.log('toggleDeskBar: start');
     toggleDeskBar(mq);
+    console.log('toggleDeskBar: done');
 
     // Formato
     document.getElementById('selAspect').addEventListener('change',(e)=> setAspect(e.target.value));


### PR DESCRIPTION
## Summary
- add start/done console logging around the key DOMContentLoaded initialization calls
- wrap the initCanvas invocation in a try/catch to surface initialization errors in the console

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8a8ffba44832ab590c5d0aced40b3