### PR TITLE
Fix fitToViewport scrolling target

### DIFF
--- a/app.js
+++ b/app.js
@@ -398,31 +398,13 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     updateZoomLabel();
     updateDesignInfo();
     if (scrollTop) {
-      // const rect = outer.getBoundingClientRect();
-      let rect = canvas.upperCanvasEl.getBoundingClientRect();
+      const rect = outer.getBoundingClientRect();
       const header = document.getElementById('deskBar');
       const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
-      let diff = rect.top - headerBottom;
-
-      console.log({
-        zoom: canvas.getZoom(),
-        scrollY: window.scrollY,
-        rectTop: rect.top,
-        headerBottom,
-        diff
-      });
-
-      while (Math.abs(diff) > 1) {
-        window.scrollBy(0, diff);
-        console.log('scrolled', diff, '=>', window.scrollY);
-        rect = canvas.upperCanvasEl.getBoundingClientRect();
-        diff = rect.top - headerBottom;
+      const target = window.scrollY + rect.top - headerBottom;
+      if (Math.abs(target - window.scrollY) > 1) {
+        window.scrollTo({ top: target, left: 0 });
       }
-
-      const headerHeight = header?.offsetHeight || 0;
-      const target = rect.top + window.scrollY - headerHeight;
-      window.scrollTo({ top: target, left: 0, behavior: 'instant' });
-
     }
 
   }


### PR DESCRIPTION
## Summary
- update `fitToViewport` to scroll to the canvas's absolute position relative to the header
- remove the incremental scroll loop in favor of a direct `scrollTo` call

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b08ad1b0832a922c73e12f4c81ce