### PR TITLE
Correct viewport height when fitting canvas

### DIFF
--- a/app.js
+++ b/app.js
@@ -377,23 +377,57 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
   function fitToViewport(scrollTop=false){
     const outer = document.getElementById('viewport');
     if(!outer||!canvas) return;
-    const ow = outer.clientWidth;
-    const oh = Math.min(outer.clientHeight, window.innerHeight);
+
+    const rect = outer.getBoundingClientRect();
+    const header = document.getElementById('deskBar');
+    const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
+    const viewportW = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportH = window.innerHeight || document.documentElement.clientHeight || 0;
+
+    const rawWidth = rect.width || outer.clientWidth || outer.offsetWidth || 0;
+    const rawHeight = rect.height || outer.clientHeight || outer.offsetHeight || 0;
+
+    const visibleWidth = Math.max(0, Math.min(rawWidth, viewportW - Math.max(rect.left, 0)));
+    const visibleHeight = Math.max(0, Math.min(rawHeight, viewportH - Math.max(rect.top, headerBottom)));
+
+    let ow = visibleWidth;
+    if (ow <= 0) {
+      ow = rawWidth > 0 ? Math.min(rawWidth, viewportW) : viewportW;
+    }
+
+    let oh = visibleHeight;
+    if (oh <= 0) {
+      const maxHeight = Math.max(0, viewportH - headerBottom);
+      const basis = rawHeight > 0 ? rawHeight : maxHeight;
+      oh = Math.min(basis, maxHeight || viewportH);
+    }
+
     if(ow <= 0 || oh <= 0){
       requestAnimationFrame(()=>fitToViewport(scrollTop));
       return;
     }
+
     const M = 24;
     const w = canvas.getWidth(), h = canvas.getHeight();
     const s  = Math.max(MIN_Z, Math.min(MAX_Z, Math.min((ow - M)/w, (oh - M)/h)));
-    const tx = (ow - w*s) / 2;
 
+    let tx = (ow - w*s) / 2;
     let ty = (oh - h*s) / 2;
-    if(scrollTop){ ty = 0; }
+
+    // Anchor to top/left if scaled canvas exceeds the viewport
+    if (w * s > ow) tx = 0;
+    if (scrollTop || h * s > oh) ty = 0;
+
     canvas.setViewportTransform([s,0,0,s,tx,ty]);
     updateZoomLabel();
     updateDesignInfo();
-    if (scrollTop) window.scrollTo(0, 0);
+
+    if (scrollTop) {
+      const targetTop = Math.max(0, window.scrollY + rect.top - headerBottom);
+      if (Math.abs(targetTop - window.scrollY) > 1) {
+        window.scrollTo({ top: targetTop, left: 0 });
+      }
+    }
 
   }
   function zoomTo(newZ, centerPoint, recenter=false){


### PR DESCRIPTION
## Summary
- derive available viewport dimensions from the visible portion of #viewport so tall canvases no longer report their full document height
- keep fitToViewport() anchored to the header while scrolling to the measured absolute top

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0a0096f30832aacc77c6b80b216cb