### PR TITLE
Adjust viewport scroll to match canvas offset

### DIFF
--- a/app.js
+++ b/app.js
@@ -419,14 +419,12 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     if (scrollTop || h * s > oh) ty = 0;
 
     canvas.setViewportTransform([s,0,0,s,tx,ty]);
+    const canvasTop = canvas.upperCanvasEl.getBoundingClientRect().top;
+    const diff = headerBottom - canvasTop;
     updateZoomLabel();
     updateDesignInfo();
-    if (scrollTop) {
-      const targetTop = Math.max(0, window.scrollY + rect.top - headerBottom);
-      if (Math.abs(targetTop - window.scrollY) > 1) {
-        window.scrollTo({ top: targetTop, left: 0 });
-
-      }
+    if (scrollTop && Math.abs(diff) > 1) {
+      window.scrollBy(0, diff);
     }
 
   }


### PR DESCRIPTION
## Summary
- measure the canvas element offset after fitting to the viewport
- scroll by the computed offset difference to keep the canvas visible when formats change

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8bb67933c832a95f53515853e1c8a