### PR TITLE
Ensure viewport fit after Fabric updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -536,7 +536,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
     addOrUpdatePaper();
     canvas.requestRenderAll();
     autoCenter = true;
-    requestAnimationFrame(() => fitToViewport(true));
+    requestAnimationFrame(() => {
+      canvas.requestRenderAll();
+      requestAnimationFrame(() => fitToViewport(true));
+    });
     updateDesignInfo();
   }
   const setBg=(color)=>{ if(paperRect){ paperRect.set({ fill: color }); } if(paperShadowRect){ paperShadowRect.set({ fill: color }); } canvas.requestRenderAll(); };
@@ -1061,7 +1064,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
   function handleResponsivePanels(){
     const mobile = window.matchMedia('(max-width: 767px)').matches;
     if (mobile) enterMobileDock(); else exitMobileDock();
-    requestAnimationFrame(()=>fitToViewport(true));
+    requestAnimationFrame(() => {
+      canvas.requestRenderAll();
+      requestAnimationFrame(() => fitToViewport(true));
+    });
   }
   function overrideOpenersForMobile(){
     const btnOpenTools = document.getElementById('btnOpenTools');
@@ -1119,7 +1125,10 @@ if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
       orderBackground();
       canvas.discardActiveObject(); canvas.requestRenderAll(); updateSelInfo();
       autoCenter = true;
-      requestAnimationFrame(() => fitToViewport(true));
+      requestAnimationFrame(() => {
+        canvas.requestRenderAll();
+        requestAnimationFrame(() => fitToViewport(true));
+      });
     });
 
     // Texto


### PR DESCRIPTION
## Summary
- wait an extra animation frame before fitting after changing the aspect ratio so the Fabric canvas has applied its transforms
- do the same when creating a new document and when responsive panels toggle to keep the canvas centered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8bb6c2d5c832a9e19e2851a4379a7