### PR TITLE
Move zoom HUD into mobile dock

### DIFF
--- a/js/ui-handlers.js
+++ b/js/ui-handlers.js
@@ -1103,6 +1103,7 @@ function buildMobileDockOnce() {
   if (!dock || dock.dataset.ready === '1') return;
   dock.dataset.ready = '1';
   dock.innerHTML = `
+    <div class="md-zoom"></div>
     <div class="md-tabs">
       <button type="button" class="md-tab" data-tab="tools">Herramientas</button>
       <button type="button" class="md-tab" data-tab="help">Ayuda</button>
@@ -1131,6 +1132,9 @@ function enterMobileDock() {
   const dock = document.getElementById('mobileDock');
   if (!left || !right || !dock) return;
   buildMobileDockOnce();
+  const zoomSlot = dock.querySelector('.md-zoom');
+  const hud = document.querySelector('#deskBar .hud');
+  if (hud && zoomSlot) zoomSlot.appendChild(hud);
   if (!leftPH) {
     leftPH = document.createElement('div');
     leftPH.id = 'leftPH';
@@ -1155,8 +1159,11 @@ function exitMobileDock() {
   const left = document.getElementById('leftPanel');
   const right = document.getElementById('rightPanel');
   const dock = document.getElementById('mobileDock');
+  const desk = document.getElementById('deskBar');
+  const hud = dock?.querySelector('.hud');
   if (leftPH && left) leftPH.parentNode.insertBefore(left, leftPH);
   if (rightPH && right) rightPH.parentNode.insertBefore(right, rightPH);
+  if (hud && desk) desk.appendChild(hud);
   if (dock) dock.style.display = 'none';
   document.body.classList.remove('mobile-docked');
   isMobileUI = false;

--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,28 @@ label.chk{ gap:6px; }
 .fp-preview { font-size: 16px; color: #374151; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display:block; margin-top:4px; }
 
 /* Mobile Dock */
+.md-zoom {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+.md-zoom:empty {
+  display: none;
+}
+.md-zoom .hud {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.md-zoom .hud > * {
+  flex: 0 0 auto;
+}
+.md-zoom .hud #zoomLabel {
+  min-width: 48px;
+  text-align: center;
+}
 .md-tabs { display: flex; gap: 8px; }
 .md-tabs button {
   flex: 1; padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 8px; background: #fff; cursor: pointer;


### PR DESCRIPTION
## Summary
- add a dedicated `.md-zoom` slot to the mobile dock markup and move the HUD into it when activating the mobile layout
- return the HUD back to the desktop bar when leaving the mobile dock
- style the new mobile zoom container so the zoom controls stay visible on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c96fdc9cbc832a8adab891349ef6c9