### PR TITLE
Add opacity slider for selected canvas objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,12 @@
             <button id="btnDup">Duplicar</button>
             <button id="btnDel">Eliminar</button>
           </div>
+          <div class="row">
+            <label>Transparencia
+              <input type="range" id="opacityControl" min="0" max="100" value="100" />
+            </label>
+            <span id="opacityValue">100%</span>
+          </div>
         </section>
 
         <section class="group">


### PR DESCRIPTION
## Summary
- add an opacity range control to the Capas tool group in the left panel
- implement helper logic to sync the slider with the active object and enable/disable it based on the selection
- update UI handlers so the control drives the active object's opacity and reflects selection changes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca29bca228832aa2d568c200792734