### PR TITLE
Actualizar color del botón de multi selección en HUD

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -75,7 +75,9 @@ label.chk{ gap:6px; }
 
 /* Zoom HUD */
 .hud button{ padding:6px 10px; border:1px solid var(--border); background:#fff; border-radius:8px; cursor:pointer; }
-#btnHandHUD.active, #btnMultiHUD.active{ background:#e5e7eb; }
+#btnHandHUD.active{ background:#e5e7eb !important; }
+#btnMultiHUD.active,
+#mobileDock .hud #btnMultiHUD.active{ background:#2563eb !important; color:#fff !important; border-color:#1d4ed8 !important; }
 
 /* Drawer behavior (desktop) */
 @media (min-width: 768px){


### PR DESCRIPTION
## Summary
- separa los estilos activos de los botones de la HUD para mantener el gris en el modo mano
- aplica un color azul llamativo al botón de multiselección activo y asegura su vigencia también en el dock móvil

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd53f821d8832aaa79157f017d1c91