### PR TITLE
Switch new text elements to Textbox

### DIFF
--- a/js/ui-handlers.js
+++ b/js/ui-handlers.js
@@ -393,11 +393,12 @@ function currentAlign() {
 function addText() {
   const canvas = canvasState.canvas;
   if (!canvas) return;
-  const it = new fabric.IText('Doble click para editar', {
+  const textbox = new fabric.Textbox('Doble click para editar', {
     left: canvasState.baseW / 2,
     top: canvasState.baseH / 2,
     originX: 'center',
     originY: 'center',
+    width: canvasState.baseW * 0.6,
     fontFamily: document.getElementById('selFont')?.value,
     fontSize: parseInt(document.getElementById('inpSize')?.value || '64', 10),
     fill: document.getElementById('inpColor')?.value,
@@ -405,8 +406,14 @@ function addText() {
     stroke: parseInt(document.getElementById('inpStrokeWidth')?.value || '0', 10) > 0 ? document.getElementById('inpStrokeColor')?.value : undefined,
     strokeWidth: parseInt(document.getElementById('inpStrokeWidth')?.value || '0', 10),
   });
-  canvas.add(it);
-  canvas.setActiveObject(it);
+  textbox.set({
+    lockScalingY: true,
+    splitByGrapheme: true,
+  });
+  canvas.add(textbox);
+  canvas.setActiveObject(textbox);
+  textbox.enterEditing();
+  textbox.hiddenTextarea?.focus();
   canvas.requestRenderAll();
   updateSelInfo();
 }
@@ -424,6 +431,10 @@ function applyTextProps() {
     strokeWidth: parseInt(document.getElementById('inpStrokeWidth')?.value || '0', 10),
     textAlign: currentAlign(),
   });
+  if (obj.type === 'textbox' && typeof obj.initDimensions === 'function') {
+    obj.initDimensions();
+    obj.setCoords();
+  }
   canvas.requestRenderAll();
   updateSelInfo();
 }


### PR DESCRIPTION
## Summary
- replace new text insertion with fabric.Textbox to allow automatic wrapping
- configure textbox controls to encourage width-only scaling and keep editing active
- refresh textbox dimensions when updating font settings

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdbfe8dab4832ab03b82af67320369