### PR TITLE
Limit textbox scaling handles

### DIFF
--- a/js/canvas-init.js
+++ b/js/canvas-init.js
@@ -127,66 +127,31 @@ function handleTextboxScaling(opt = {}) {
     opt.transform.originY,
   );
 
-  if (corner === 'ml' || corner === 'mr') {
-    const nextWidth = (target.width || 0) * (target.scaleX || 1);
-    target.set({
-      width: nextWidth,
-      scaleX: 1,
-      scaleY: 1,
-    });
-    target.initDimensions?.();
-    if (anchor) {
-      target.setPositionByOrigin(
-        anchor,
-        opt.transform.originX,
-        opt.transform.originY,
-      );
-    }
-    target.setCoords();
-    if (opt.transform) {
-      opt.transform.scaleX = opt.transform.scaleY = 1;
-      if (opt.transform.original) {
-        opt.transform.original.scaleX = opt.transform.original.scaleY = 1;
-      }
-    }
-    target.canvas?.requestRenderAll();
-    updateSelInfo();
-    return;
-  }
+  if (corner !== 'ml' && corner !== 'mr') return;
 
-  if (corner === 'tl' || corner === 'tr' || corner === 'bl' || corner === 'br') {
-    if (!target.__baseTextScale) {
-      target.__baseTextScale = {
-        fontSize: target.fontSize,
-        width: target.width,
-      };
-    }
-    const base = target.__baseTextScale;
-    const factor = Math.max(target.scaleX || 1, target.scaleY || 1);
-    target.set({
-      fontSize: (base.fontSize || target.fontSize) * factor,
-      width: (base.width || target.width || 0) * factor,
-      scaleX: 1,
-      scaleY: 1,
-    });
-    target.initDimensions?.();
-    if (anchor) {
-      target.setPositionByOrigin(
-        anchor,
-        opt.transform.originX,
-        opt.transform.originY,
-      );
-    }
-    target.setCoords();
-    if (opt.transform) {
-      opt.transform.scaleX = opt.transform.scaleY = 1;
-      if (opt.transform.original) {
-        opt.transform.original.scaleX = opt.transform.original.scaleY = 1;
-      }
-    }
-    target.canvas?.requestRenderAll();
-    updateSelInfo();
+  const nextWidth = (target.width || 0) * (target.scaleX || 1);
+  target.set({
+    width: nextWidth,
+    scaleX: 1,
+    scaleY: 1,
+  });
+  target.initDimensions?.();
+  if (anchor) {
+    target.setPositionByOrigin(
+      anchor,
+      opt.transform.originX,
+      opt.transform.originY,
+    );
   }
+  target.setCoords();
+  if (opt.transform) {
+    opt.transform.scaleX = opt.transform.scaleY = 1;
+    if (opt.transform.original) {
+      opt.transform.original.scaleX = opt.transform.original.scaleY = 1;
+    }
+  }
+  target.canvas?.requestRenderAll();
+  updateSelInfo();
 }
 
 function finalizeTextboxScaling(opt = {}) {

--- a/js/ui-handlers.js
+++ b/js/ui-handlers.js
@@ -390,6 +390,20 @@ function currentAlign() {
   return btn?.dataset?.align || 'left';
 }
 
+const TEXTBOX_CONTROL_VISIBILITY = {
+  mt: false,
+  mb: false,
+  tl: false,
+  tr: false,
+  bl: false,
+  br: false,
+};
+
+function applyTextboxControlVisibility(textbox) {
+  if (!textbox || textbox.type !== 'textbox' || typeof textbox.setControlsVisibility !== 'function') return;
+  textbox.setControlsVisibility({ ...TEXTBOX_CONTROL_VISIBILITY });
+}
+
 function addText() {
   const canvas = canvasState.canvas;
   if (!canvas) return;
@@ -406,7 +420,7 @@ function addText() {
     stroke: parseInt(document.getElementById('inpStrokeWidth')?.value || '0', 10) > 0 ? document.getElementById('inpStrokeColor')?.value : undefined,
     strokeWidth: parseInt(document.getElementById('inpStrokeWidth')?.value || '0', 10),
   });
-  textbox.setControlsVisibility({ mt: false, mb: false });
+  applyTextboxControlVisibility(textbox);
   canvas.add(textbox);
   canvas.setActiveObject(textbox);
   textbox.enterEditing();
@@ -1458,6 +1472,16 @@ export function setupUIHandlers() {
   document.getElementById('btnBwd')?.addEventListener('click', sendBackwards);
   document.getElementById('btnDup')?.addEventListener('click', duplicateActive);
   document.getElementById('btnDel')?.addEventListener('click', removeActive);
+
+  const canvas = canvasState.canvas;
+  if (canvas) {
+    canvas.on('object:added', (opt) => {
+      const target = opt?.target;
+      if (target?.type === 'textbox') {
+        applyTextboxControlVisibility(target);
+      }
+    });
+  }
 
   const opacityControl = document.getElementById('opacityControl');
   const opacityValue = document.getElementById('opacityValue');


### PR DESCRIPTION
## Summary
- hide textbox corner and vertical controls so only side handles and rotation remain active
- reapply the restricted controls whenever a textbox is added to the canvas
- simplify textbox scaling logic to work solely with lateral handles

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cddbdd6f54832aaddd66767fc8212f