### PR TITLE
Add text background controls and syncing

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,10 @@
             <label>Color <input id="inpColor" type="color" value="#111827" /></label>
           </div>
           <div class="row">
+            <label>Fondo <input id="inpTextBg" type="color" value="#ffffff" /></label>
+            <label class="chk"><input type="checkbox" id="chkTextBgNone" /> Sin relleno</label>
+          </div>
+          <div class="row">
             <label style="flex: 1 1 auto;">Tamaño
               <input id="sizeSlider" type="range" value="64" min="8" max="200" step="1" />
             </label>


### PR DESCRIPTION
## Summary
- add a background color picker with a "sin relleno" toggle to the text tools panel
- apply textbox background colors when creating or updating text and keep control state in sync with the active selection
- wire the new controls to live updates and selection events so they disable when no single textbox is selected

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cdea9f6d54832abff9d968778106f5