### PR TITLE
Hide desktop drawers when closed

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 
   <main id="app">
     <!-- Panel izquierdo (herramientas) -->
-    <aside id="leftPanel" class="panel">
+    <aside id="leftPanel" class="panel open">
       <div class="panel-head">
         <h2>Herramientas</h2>
         <button id="btnCloseTools" class="close">✕</button>
@@ -261,7 +261,7 @@
     <div id="mobileDock"></div>
 
     <!-- Panel derecho (ayuda) -->
-    <aside id="rightPanel" class="panel">
+    <aside id="rightPanel" class="panel open">
       <div class="panel-head">
         <h2>Ayuda</h2>
         <button id="btnCloseHelp" class="close">✕</button>

--- a/js/ui-handlers.js
+++ b/js/ui-handlers.js
@@ -102,7 +102,7 @@ function attachDrawerButtons() {
     refreshViewport();
   });
   document.getElementById('btnOpenHelp')?.addEventListener('click', () => {
-    document.getElementById('rightPanel')?.classList.toggle('open');
+    document.getElementById('rightPanel')?.classList.add('open');
     refreshViewport();
   });
   document.getElementById('btnCloseHelp')?.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,7 @@ label.chk{ gap:6px; }
 /* Drawer behavior (desktop) */
 @media (min-width: 768px){
   #leftPanel, #rightPanel{ display:flex; }
+  #leftPanel:not(.open), #rightPanel:not(.open){ display:none; }
 }
 
 /* Mobile: columnas colapsan, dock debajo del lienzo */


### PR DESCRIPTION
## Summary
- hide desktop panels on large screens when they lack the `open` class
- ensure both tool and help panels start opened to match previous behavior
- make the help open button add the `open` class so the drawer actually reappears

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cec5e8cb10832a836278176b12de3f