### PR TITLE
Adjust desktop layout when help panel closed

### DIFF
--- a/js/ui-handlers.js
+++ b/js/ui-handlers.js
@@ -79,12 +79,18 @@ function toggleDeskBar(e) {
   setHeaderHeight(true);
 }
 
+function syncAppColumns() {
+  const isRightPanelOpen = document.getElementById('rightPanel')?.classList.contains('open');
+  document.body.classList.toggle('help-closed', !isRightPanelOpen);
+}
+
 function syncDrawers() {
   const isDesktop = window.matchMedia('(min-width: 768px)').matches;
   if (isDesktop) {
     document.getElementById('leftPanel')?.classList.remove('open');
     document.getElementById('rightPanel')?.classList.remove('open');
   }
+  syncAppColumns();
 }
 function attachDrawerButtons() {
   const refreshViewport = () => {
@@ -95,20 +101,26 @@ function attachDrawerButtons() {
 
   document.getElementById('btnOpenTools')?.addEventListener('click', () => {
     document.getElementById('leftPanel')?.classList.toggle('open');
+    syncAppColumns();
     refreshViewport();
   });
   document.getElementById('btnCloseTools')?.addEventListener('click', () => {
     document.getElementById('leftPanel')?.classList.remove('open');
+    syncAppColumns();
     refreshViewport();
   });
   document.getElementById('btnOpenHelp')?.addEventListener('click', () => {
     document.getElementById('rightPanel')?.classList.add('open');
+    syncAppColumns();
     refreshViewport();
   });
   document.getElementById('btnCloseHelp')?.addEventListener('click', () => {
     document.getElementById('rightPanel')?.classList.remove('open');
+    syncAppColumns();
     refreshViewport();
   });
+
+  syncAppColumns();
 }
 
 export function injectGoogleFonts() {

--- a/styles.css
+++ b/styles.css
@@ -83,6 +83,7 @@ label.chk{ gap:6px; }
 @media (min-width: 768px){
   #leftPanel, #rightPanel{ display:flex; }
   #leftPanel:not(.open), #rightPanel:not(.open){ display:none; }
+  body.help-closed #app{ grid-template-columns: 280px 1fr; }
 }
 
 /* Mobile: columnas colapsan, dock debajo del lienzo */


### PR DESCRIPTION
## Summary
- add a desktop-only grid override so the canvas expands when the help panel is hidden
- sync a body flag with the right drawer state to keep the layout responsive across viewport changes

## Testing
- Manual verification in browser (closing and reopening help panel)


------
https://chatgpt.com/codex/tasks/task_e_68ced1ec1a54832a873c51da7fffdd6f